### PR TITLE
Add support of custom DataLayer variable name

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -123,8 +123,10 @@ const gtm_debug = requestParams.gtm_debug;
 const gtm_preview = requestParams.gtm_preview;
 const previewRequest = !!(gtm_auth && gtm_debug && gtm_preview);
 
+const dataLayerVariableNameParameter = requestParams.l ? '&l=' + requestParams.l : '';
+
 // Set names for storage
-const storedJs = 'gtm_js_' + containerId;
+const storedJs = 'gtm_js_' + containerId + (requestParams.l ? '_' + requestParams.l : '');
 const storedHeaders = storedJs + '_headers';
 const storedTimeout = storedJs + '_timeout';
 
@@ -150,7 +152,7 @@ const sendResponse = (response, headers, statusCode) => {
 
 const fetchPreviewContainer = () => {
   log('Fetching preview container for ' + containerId);
-  sendHttpGet(httpEndpoint + '&id=' + containerId + '&gtm_auth=' + gtm_auth + '&gtm_debug=' + gtm_debug + '&gtm_preview=' + gtm_preview, (statusCode, headers, body) => {
+  sendHttpGet(httpEndpoint + '&id=' + containerId + '&gtm_auth=' + gtm_auth + '&gtm_debug=' + gtm_debug + '&gtm_preview=' + gtm_preview + dataLayerVariableNameParameter, (statusCode, headers, body) => {
     sendResponse(body, headers, statusCode);
   }, {timeout: 1500});
 };
@@ -161,7 +163,7 @@ const fetchLiveContainer = () => {
   if (!templateDataStorage.getItemCopy(storedJs) || 
       templateDataStorage.getItemCopy(storedTimeout) < storageTimeout) {
     log('Fetching live container from GTM servers for ' + containerId);
-    sendHttpGet(httpEndpoint + '&id=' + containerId, (statusCode, headers, body) => {
+    sendHttpGet(httpEndpoint + '&id=' + containerId + dataLayerVariableNameParameter, (statusCode, headers, body) => {
       if (statusCode === 200) {
         templateDataStorage.setItemCopy(storedJs, body);
         templateDataStorage.setItemCopy(storedHeaders, headers);


### PR DESCRIPTION
Now there is no possibility to use this client in case the dataLayer variable is renamed. 
This PR fixes this issue.