### PR TITLE
Custom dl and env support

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -78,11 +78,32 @@ ___TEMPLATE_PARAMETERS___
   },
   {
     "type": "CHECKBOX",
+    "name": "overrideDl",
+    "checkboxText": "Override Data Layer Name",
+    "simpleValueType": true,
+    "help": "With this setting, you can define your own dataLayer name instead of using the default dataLayer object. Please make sure that this name exactly matches your implementation."
+  },
+  {
+    "type": "TEXT",
+    "name": "dataLayerName",
+    "displayName": "Data Layer Name",
+    "simpleValueType": true,
+    "enablingConditions": [
+      {
+        "paramName": "overrideDl",
+        "paramValue": true,
+        "type": "EQUALS"
+      }
+    ],
+    "defaultValue": "dataLayer"
+  },
+  {
+    "type": "CHECKBOX",
     "name": "encodingHeader",
     "checkboxText": "Set Encoding Header (Recommended for Cloud Run)",
     "simpleValueType": true,
     "help": "If you check this, a \"Content-Encoding\" header with the value \"gzip\" will be set in the response back to the browser."
-  },  
+  },
   {
     "type": "TEXT",
     "name": "allowedOrigins",
@@ -105,6 +126,7 @@ const claimRequest = require('claimRequest');
 const getRequestHeader = require('getRequestHeader');
 const getRequestPath = require('getRequestPath');
 const getRequestQueryParameters = require('getRequestQueryParameters');
+const getRequestQueryString = require('getRequestQueryString');
 const getTimestampMillis = require('getTimestampMillis');
 const logToConsole = require('logToConsole');
 const parseUrl = require('parseUrl');
@@ -117,6 +139,7 @@ const templateDataStorage = require('templateDataStorage');
 
 const requestPath = getRequestPath();
 const requestParams = getRequestQueryParameters();
+const requestQueryString = getRequestQueryString();
 
 const origin = getRequestHeader('origin') || (!!getRequestHeader('referer') && parseUrl(getRequestHeader('referer')).origin) || requestParams.origin;
 const approvedResponseHeaders = ['last-modified', 'cache-control', 'content-type', 'vary', 'alt-svc', 'server', 'content-encoding'];
@@ -126,15 +149,14 @@ const cacheMaxTimeInMs = 450000;
 const containerId = data.containerId || requestParams.id || '';
 
 // Preview parameters
-const gtm_auth = requestParams.gtm_auth;
 const gtm_debug = requestParams.gtm_debug;
-const gtm_preview = requestParams.gtm_preview;
-const previewRequest = !!(gtm_auth && gtm_debug && gtm_preview);
+const previewRequest = !!(gtm_debug);
 
-const dataLayerVariableNameParameter = requestParams.l ? '&l=' + requestParams.l : '';
+const requestParamsString = requestQueryString === '' ? '' : '&' + requestQueryString;
+const dataLayerVariableNameParameter = data.overrideDl ? '&l=' + data.dataLayerName : '';
 
 // Set names for storage
-const storedJs = 'gtm_js_' + containerId + (requestParams.l ? '_' + requestParams.l : '');
+const storedJs = 'gtm_js_' + containerId + (data.overrideDl ? '_' + data.dataLayerName : '');
 const storedHeaders = storedJs + '_headers';
 const storedTimeout = storedJs + '_timeout';
 
@@ -163,7 +185,7 @@ const sendResponse = (response, headers, statusCode) => {
 
 const fetchPreviewContainer = () => {
   log('Fetching preview container for ' + containerId);
-  sendHttpGet(httpEndpoint + '&id=' + containerId + '&gtm_auth=' + gtm_auth + '&gtm_debug=' + gtm_debug + '&gtm_preview=' + gtm_preview + dataLayerVariableNameParameter, (statusCode, headers, body) => {
+  sendHttpGet(httpEndpoint + '&id=' + containerId + requestParamsString + dataLayerVariableNameParameter, (statusCode, headers, body) => {
     sendResponse(body, headers, statusCode);
   }, {timeout: 1500});
 };
@@ -174,7 +196,7 @@ const fetchLiveContainer = () => {
   if (!templateDataStorage.getItemCopy(storedJs) || 
       templateDataStorage.getItemCopy(storedTimeout) < storageTimeout) {
     log('Fetching live container from GTM servers for ' + containerId);
-    sendHttpGet(httpEndpoint + '&id=' + containerId + dataLayerVariableNameParameter, (statusCode, headers, body) => {
+    sendHttpGet(httpEndpoint + '&id=' + containerId + requestParamsString + dataLayerVariableNameParameter, (statusCode, headers, body) => {
       if (statusCode === 200) {
         templateDataStorage.setItemCopy(storedJs, body);
         templateDataStorage.setItemCopy(storedHeaders, headers);

--- a/template.tpl
+++ b/template.tpl
@@ -81,7 +81,7 @@ ___TEMPLATE_PARAMETERS___
     "name": "overrideDl",
     "checkboxText": "Override Data Layer Name",
     "simpleValueType": true,
-    "help": "With this setting, you can define your own dataLayer name instead of using the default dataLayer object. Please make sure that this name exactly matches your implementation."
+    "help": "With this setting, you can define your own Data Layer name instead of using the default dataLayer object. Please make sure that this name exactly matches your implementation."
   },
   {
     "type": "TEXT",

--- a/template.tpl
+++ b/template.tpl
@@ -95,7 +95,11 @@ ___TEMPLATE_PARAMETERS___
         "type": "EQUALS"
       }
     ],
-    "defaultValue": "dataLayer"
+    "valueValidators": [
+      {
+        "type": "NON_EMPTY"
+      }
+    ]
   },
   {
     "type": "CHECKBOX",
@@ -126,7 +130,6 @@ const claimRequest = require('claimRequest');
 const getRequestHeader = require('getRequestHeader');
 const getRequestPath = require('getRequestPath');
 const getRequestQueryParameters = require('getRequestQueryParameters');
-const getRequestQueryString = require('getRequestQueryString');
 const getTimestampMillis = require('getTimestampMillis');
 const logToConsole = require('logToConsole');
 const parseUrl = require('parseUrl');
@@ -139,24 +142,27 @@ const templateDataStorage = require('templateDataStorage');
 
 const requestPath = getRequestPath();
 const requestParams = getRequestQueryParameters();
-const requestQueryString = getRequestQueryString();
 
 const origin = getRequestHeader('origin') || (!!getRequestHeader('referer') && parseUrl(getRequestHeader('referer')).origin) || requestParams.origin;
 const approvedResponseHeaders = ['last-modified', 'cache-control', 'content-type', 'vary', 'alt-svc', 'server', 'content-encoding'];
 
 // Set max template storage cache to half of GTM container cache
 const cacheMaxTimeInMs = 450000;
+
+//get container ID and data layer name
 const containerId = data.containerId || requestParams.id || '';
+const dataLayerName = data.dataLayerName || requestParams.l || '';
+const dataLayerNameParameter = dataLayerName !== '' ? '&l=' + dataLayerName : '';
 
-// Preview parameters
-const gtm_debug = requestParams.gtm_debug;
-const previewRequest = !!(gtm_debug);
-
-const requestParamsString = requestQueryString === '' ? '' : '&' + requestQueryString;
-const dataLayerVariableNameParameter = data.overrideDl ? '&l=' + data.dataLayerName : '';
+// Preview and environment parameters
+const authParameter = requestParams.gtm_auth ? '&gtm_auth=' + requestParams.gtm_auth : '';
+const debugParameter = requestParams.gtm_debug ? '&gtm_debug=' + requestParams.gtm_debug : '';
+const previewParameter = requestParams.gtm_preview ? '&gtm_preview=' + requestParams.gtm_preview : '';
+const cookiesWinParameter = requestParams.gtm_cookies_win ? '&gtm_cookies_win=' + requestParams.gtm_cookies_win : '';
+const previewRequest = !!(requestParams.gtm_debug);
 
 // Set names for storage
-const storedJs = 'gtm_js_' + containerId + (data.overrideDl ? '_' + data.dataLayerName : '');
+const storedJs = 'gtm_js_' + containerId + ((data.dataLayerName || requestParams.l) ? '_' + dataLayerName : '');
 const storedHeaders = storedJs + '_headers';
 const storedTimeout = storedJs + '_timeout';
 
@@ -185,7 +191,7 @@ const sendResponse = (response, headers, statusCode) => {
 
 const fetchPreviewContainer = () => {
   log('Fetching preview container for ' + containerId);
-  sendHttpGet(httpEndpoint + '&id=' + containerId + requestParamsString + dataLayerVariableNameParameter, (statusCode, headers, body) => {
+  sendHttpGet(httpEndpoint + '&id=' + containerId + authParameter + debugParameter + previewParameter + dataLayerNameParameter, (statusCode, headers, body) => {
     sendResponse(body, headers, statusCode);
   }, {timeout: 1500});
 };
@@ -196,7 +202,7 @@ const fetchLiveContainer = () => {
   if (!templateDataStorage.getItemCopy(storedJs) || 
       templateDataStorage.getItemCopy(storedTimeout) < storageTimeout) {
     log('Fetching live container from GTM servers for ' + containerId);
-    sendHttpGet(httpEndpoint + '&id=' + containerId + requestParamsString + dataLayerVariableNameParameter, (statusCode, headers, body) => {
+    sendHttpGet(httpEndpoint + '&id=' + containerId + authParameter + previewParameter + cookiesWinParameter + dataLayerNameParameter, (statusCode, headers, body) => {
       if (statusCode === 200) {
         templateDataStorage.setItemCopy(storedJs, body);
         templateDataStorage.setItemCopy(storedHeaders, headers);

--- a/template.tpl
+++ b/template.tpl
@@ -159,7 +159,7 @@ const authParameter = requestParams.gtm_auth ? '&gtm_auth=' + requestParams.gtm_
 const debugParameter = requestParams.gtm_debug ? '&gtm_debug=' + requestParams.gtm_debug : '';
 const previewParameter = requestParams.gtm_preview ? '&gtm_preview=' + requestParams.gtm_preview : '';
 const cookiesWinParameter = requestParams.gtm_cookies_win ? '&gtm_cookies_win=' + requestParams.gtm_cookies_win : '';
-const previewRequest = !!(requestParams.gtm_auth && requestParams.gtm_debug && requestParams.gtm_preview);
+const previewRequest = !!(requestParams.gtm_auth || requestParams.gtm_debug || requestParams.gtm_preview);
 
 // Set names for storage
 const storedJs = 'gtm_js_' + containerId + (dataLayerName !== '' ? '_' + dataLayerName : '');
@@ -191,7 +191,7 @@ const sendResponse = (response, headers, statusCode) => {
 
 const fetchPreviewContainer = () => {
   log('Fetching preview container for ' + containerId);
-  sendHttpGet(httpEndpoint + '&id=' + containerId + authParameter + debugParameter + previewParameter + dataLayerNameParameter, (statusCode, headers, body) => {
+  sendHttpGet(httpEndpoint + '&id=' + containerId + authParameter + debugParameter + previewParameter + cookiesWinParameter + dataLayerNameParameter, (statusCode, headers, body) => {
     sendResponse(body, headers, statusCode);
   }, {timeout: 1500});
 };
@@ -202,7 +202,7 @@ const fetchLiveContainer = () => {
   if (!templateDataStorage.getItemCopy(storedJs) || 
       templateDataStorage.getItemCopy(storedTimeout) < storageTimeout) {
     log('Fetching live container from GTM servers for ' + containerId);
-    sendHttpGet(httpEndpoint + '&id=' + containerId + authParameter + previewParameter + cookiesWinParameter + dataLayerNameParameter, (statusCode, headers, body) => {
+    sendHttpGet(httpEndpoint + '&id=' + containerId + dataLayerNameParameter, (statusCode, headers, body) => {
       if (statusCode === 200) {
         templateDataStorage.setItemCopy(storedJs, body);
         templateDataStorage.setItemCopy(storedHeaders, headers);

--- a/template.tpl
+++ b/template.tpl
@@ -159,10 +159,10 @@ const authParameter = requestParams.gtm_auth ? '&gtm_auth=' + requestParams.gtm_
 const debugParameter = requestParams.gtm_debug ? '&gtm_debug=' + requestParams.gtm_debug : '';
 const previewParameter = requestParams.gtm_preview ? '&gtm_preview=' + requestParams.gtm_preview : '';
 const cookiesWinParameter = requestParams.gtm_cookies_win ? '&gtm_cookies_win=' + requestParams.gtm_cookies_win : '';
-const previewRequest = !!(requestParams.gtm_debug);
+const previewRequest = !!(requestParams.gtm_auth && requestParams.gtm_debug && requestParams.gtm_preview);
 
 // Set names for storage
-const storedJs = 'gtm_js_' + containerId + ((data.dataLayerName || requestParams.l) ? '_' + dataLayerName : '');
+const storedJs = 'gtm_js_' + containerId + (dataLayerName !== '' ? '_' + dataLayerName : '');
 const storedHeaders = storedJs + '_headers';
 const storedTimeout = storedJs + '_timeout';
 


### PR DESCRIPTION
Hi Simo,
I really appreciate your GTM Loader Template but we had to adjust it to match our needs and I though it would be a great idea to create a pull request so others can benefit from our adjustments as well :)

I added the option to override the data layer name, so in the same way as the Container ID does not need to be part of the request URL, the Data Layer Name with the query parameter "l" does not need to be part of the request params but can be set in the client settings.

Additionally I added support for the GTM Environments. So far the gtm_preview and gtm_auth parameters were only forwarded if the gtm_debug parameter was present. Now I updated the code to make sure that all gtm params for the environments are forwarded to googletagmanager.com and that this is handled as preview request as well. This adds support for own gtm environments where the request contains the gtm_auth, gtm_preview and gtm_cookies_win parameters but no gtm_debug parameter.

I hope you find this valuable and I would be very happy if this will be merged in the official repository :)

Best regards
Florian